### PR TITLE
Updating case of logrus reference

### DIFF
--- a/openflow13/flowmod.go
+++ b/openflow13/flowmod.go
@@ -3,7 +3,7 @@ package openflow13
 import (
 	"encoding/binary"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/shaleman/libOpenflow/common"
 )
 

--- a/openflow13/group.go
+++ b/openflow13/group.go
@@ -5,7 +5,7 @@ package openflow13
 import (
 	"encoding/binary"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/shaleman/libOpenflow/common"
 )
 

--- a/openflow13/multipart.go
+++ b/openflow13/multipart.go
@@ -3,7 +3,7 @@ package openflow13
 import (
 	"encoding/binary"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/shaleman/libOpenflow/common"
 	"github.com/shaleman/libOpenflow/util"

--- a/util/stream.go
+++ b/util/stream.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type BufferPool struct {


### PR DESCRIPTION
Logrus renamed their project to lowercase "sirupsen", and having both versions around causes build errors.

See https://github.com/sirupsen/logrus/issues/451 for more info. This just matches the new case going forward.